### PR TITLE
Update `rework-suit-conformance` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   ],
   "dependencies": {
     "rework": "0.20.x",
-    "rework-suit-conformance": "~0.1.0"
+    "rework-suit-conformance": "^0.2.0"
   },
   "devDependencies": {
     "component-builder": "0.11.x",


### PR DESCRIPTION
Fix annoying "Invalid custom property" error that components using the latest CSS variables syntax experience when the latest `component-builder-suit` is used.
## 

This also affects `v0.3.0` of [grunt-suitcss](https://github.com/simonsmith/grunt-suitcss), (Cc: @simonsmith).
